### PR TITLE
add elixir implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ For more, explore [the *age-encryption* GitHub topic](https://github.com/topics/
 
 * [agemobile](https://github.com/MarinX/agemobile) — gomobile support for age.
 
+* 🧪 [age_ex](https://hexdocs.pm/age/)  - Elixir implementation using libsodium and :crypto.
+
 ## Plugins
 
 * ⭐️ [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) — YubiKey (and other PIV tokens) plugin.


### PR DESCRIPTION
Heya!
I implemented age in Elixir, since I couldn't find an existing library that does so. It uses libsodium and Erlangs inbuilt crypto module.
Source is [here](https://ravy.dev/root/age_ex). It's published on hex as `age` and has [docs](https://hexdocs.pm/age/) there as well. I've marked it as beta since it only implements basic functionality and X25519 identities. Would love to do full compatibility soon though.