### PR TITLE
Add link to Jagged Java library implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ For more, explore [the *age-encryption* GitHub topic](https://github.com/topics/
 
 * [pyrage](https://github.com/woodruffw/pyrage) — Python bindings for rage.
 
+* [Jagged](https://github.com/exceptionfactory/jagged) - Java library implementation.
+
 * 🧪 [kage](https://github.com/android-password-store/kage) — Work-in-progress implementation for Kotlin/JVM and Android.
 
 * 🧪 [AgeKit](https://github.com/jamesog/AgeKit) — Work-in-progress Swift implementation on top of CryptoKit.


### PR DESCRIPTION
This pull request adds a link to a new Java library implementation of age encryption.

The Jagged library builds on the Java Cryptography Architecture framework, supporting Java 11 and 17 without additional dependencies. Jagged also supports Java 8 using the [Bouncy Castle](https://bouncycastle.org/java.html) security provider.

The library includes extensive unit testing and also uses the Community Cryptography Test Vectors for age in the [CommunityCryptographyTest](https://github.com/exceptionfactory/jagged/blob/main/jagged-test/src/test/java/com/exceptionfactory/jagged/test/CommunityCryptographyTest.java) class.

An initial release version should be coming soon.

Thanks for the great work on a clear specification and extensive test vectors!