### PR TITLE
Add vanity-rage

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ For more, explore [the *age-encryption* GitHub topic](https://github.com/topics/
 
 * [vanity-age](https://github.com/seaofmars/vanity-age) — Vanity age public key bruteforcer.
 
+* [vanity-rage](https://github.com/siltyy/vanity-rage) — Faster rage-based reimplementation of vanity-age.
+
 * [age-op](https://github.com/stevelr/age-op) — Transparently use age keys stored in 1Password.
 
 ## Integrations


### PR DESCRIPTION
Adds a link to [vanity-rage](https://github.com/siltyy/vanity-rage/tree/master), a vanity key bruteforcer and a rage equivalent to [vanity-age](https://github.com/6e6f61/vanity-age).