### PR TITLE
Add OpenPGP Card age plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For more, explore [the *age-encryption* GitHub topic](https://github.com/topics/
 
 * 🧪 [age-plugin-sss](https://github.com/olastor/age-plugin-sss) — Plugin for splitting encryption keys using Shamir's Secret Sharing (SSS).
 
+* [age-plugin-openpgp-card](https://github.com/wiktor-k/age-plugin-openpgp-card) - Yubikey, Nitrokey (and other OpenPGP Card tokens) plugin with support for curve25519.
+
 ## GUIs
 
 * ⭐️ [Winage](https://winage.spiegl.dev/) — Contextual menu driven Windows GUI.


### PR DESCRIPTION
Add plugin for reusing curve25519 keys on OpenPGP Card devices.