### PR TITLE
Add offkey tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The Go package [filippo.io/age/plugin](https://pkg.go.dev/filippo.io/age@v1.2.1-
 
 * [PaperAge](https://github.com/matiaskorhonen/paper-age) — Easy and secure paper backups of secrets.
 
+* [offkey](https://github.com/yawn/offkey) — Print age encrypted small secrets for offline recovery.
+
 * [pa](https://github.com/biox/pa) — A simple password manager, written in portable POSIX shell.
 
 * [agebox](https://github.com/slok/agebox) — Easy file repository encryption tool, focused on simplicity and gitops.


### PR DESCRIPTION
Just stumbled upon the `awesome-age` repo and added the `offkey` for printing age-encrypted secrets.

This is _very_ similar to the (more recent) `paper-age` project. Main difference (as far as I can see from a cursory glance) are passphrase handling (supplied vs. generated) and output generation (PDF vs. browser).