### PR TITLE
Add https://github.com/AlexanderYastrebov/age-vanity-keygen

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The Go package [filippo.io/age/plugin](https://pkg.go.dev/filippo.io/age@v1.2.1-
 
 * [age-keygen-deterministic](https://github.com/keisentraut/age-keygen-deterministic) — Deterministically generate age keys from a passphrase with Argon2id.
 
-* [vanity-age](https://github.com/seaofmars/vanity-age) — Vanity age public key bruteforcer.
+* [age-vanity-keygen](https://github.com/AlexanderYastrebov/age-vanity-keygen) — Fast vanity age X25519 identity generator.
 
 * [vanity-rage](https://github.com/siltyy/vanity-rage) — Faster rage-based reimplementation of vanity-age.
 


### PR DESCRIPTION
[This tool](https://github.com/AlexanderYastrebov/age-vanity-keygen) generates age X25519 identity with a recipient that has a specified prefix. The output is identical to `age-keygen`.

Compared to similar tools, it uses the fastest search algorithm, see [vanity25519](https://github.com/AlexanderYastrebov/vanity25519) for algorithm implementation 🚀

Also remove dead link to https://github.com/seaofmars/vanity-age