### PR TITLE
add Caesar

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The Go package [filippo.io/age/plugin](https://pkg.go.dev/filippo.io/age@v1.2.1-
 
 * [age-online](https://github.com/nkcmr/age-online) ([live](https://age-online.com/)) — Wasm in-browser encryption/decryption tool for text.
 
+* [Caesar](https://github.com/fibo/Caesar) - Desktop app based on Electron.
+
 ## Tools
 
 * ⭐️ [passage](https://github.com/FiloSottile/passage) — Fork of password-store that uses age in place of gpg.


### PR DESCRIPTION
[Caesar](https://github.com/fibo/Caesar) is a desktop app based on Electron.

For now it supports Mac and Windows.

It is at an early stage, I just released a first basic version that lets encrypt/decrypt files using a passphrase.

It can generate a passphrase with up to 10 BIP39 words.

By design it __never__ connects to the Internet, automatic updates are not implemented.

It has no dependencies other than `typeage`.