### PR TITLE
Add age-keygen-det to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The Go package [filippo.io/age/plugin](https://pkg.go.dev/filippo.io/age@v1.2.1-
 
 * [age-keygen-deterministic](https://github.com/keisentraut/age-keygen-deterministic) — Deterministically generate age keys from a passphrase with Argon2id.
 
+* [age-keygen-det](https://github.com/dmonakhov/age-keygen-det) — Deterministically derive classic or post-quantum age identities from a 32-byte seed, e.g. a BIP-85 hardware-wallet entropy output.
+
 * [age-vanity-keygen](https://github.com/AlexanderYastrebov/age-vanity-keygen) — Fast vanity age X25519 identity generator.
 
 * [vanity-rage](https://github.com/siltyy/vanity-rage) — Faster rage-based reimplementation of vanity-age.


### PR DESCRIPTION
Tool which encode raw hex32 entropy  as age private key.  
People who already secure a BIP-39 mnemonic have, over the years, built up a lot of practice around it: paper backups, metal plates, geographic redundancy, seed-sharding schemes (SeedXOR, etc.), and air-gapped hardware-wallet workflows. [BIP-85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki) layers application-specific entropy derivation on top of that same root, and any 32-byte output of BIP-85's HEX application is a valid input for age-keygen-det. So the "where do I back up my age key" problem reduces to the already-solved "where do I back up my BIP-39 seed" problem - no new physical procedure, no new envelope, no parallel sharding plan.
